### PR TITLE
Fix Token Filter

### DIFF
--- a/services/block_service.go
+++ b/services/block_service.go
@@ -125,8 +125,8 @@ func (s *BlockAPIService) PopulateTransaction(
 		if !ContainsTopic(log, encodedTransferMethod) {
 			continue
 		}
-		if s.client.GetRosettaConfig().FilterTokens &&
-			!client.IsValidERC20Token(s.client.GetRosettaConfig().TokenWhiteList, log.Address.String()) {
+		if !s.client.GetRosettaConfig().FilterTokens || (s.client.GetRosettaConfig().FilterTokens &&
+			client.IsValidERC20Token(s.client.GetRosettaConfig().TokenWhiteList, log.Address.String())) {
 			switch len(log.Topics) {
 			case TopicsInErc20Transfer:
 				currency, err := s.client.GetContractCurrency(log.Address, true)

--- a/services/block_service_test.go
+++ b/services/block_service_test.go
@@ -389,6 +389,18 @@ func TestBlockService_Online(t *testing.T) {
 			TxHash:  common.HexToHash(hsh),
 		}
 
+		mockClient.On(
+			"GetContractCurrency",
+			mock.Anything,
+			mock.Anything,
+		).Return(
+			&client.ContractCurrency{
+				Symbol:   "USDC",
+				Decimals: 6,
+			},
+			nil,
+		).Once()
+
 		receipt := client.RosettaTxReceipt{
 			TransactionFee: big.NewInt(10000),
 			Logs:           []*EthTypes.Log{&log},
@@ -482,7 +494,7 @@ func TestBlockService_Online(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, blockResp.Block.BlockIdentifier, b.Block.BlockIdentifier)
 		assert.Equal(t, 1, len(b.Block.Transactions))
-		assert.Equal(t, 3, len(b.Block.Transactions[0].Operations))
+		assert.Equal(t, 5, len(b.Block.Transactions[0].Operations))
 		// FEE operation
 		assert.Equal(t, "FEE", b.Block.Transactions[0].Operations[0].Type)
 		assert.Equal(t, "-10000", b.Block.Transactions[0].Operations[0].Amount.Value)


### PR DESCRIPTION
Fixes # .
Fixing token filter logic so we only parse tokens if the token filter is false or the token filter is true and the token is a valid erc20 token

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
