### PR TITLE
Rosetta-geth-sdk should populate txn type in RosettaTxReceipt

### DIFF
--- a/client/types.go
+++ b/client/types.go
@@ -131,6 +131,7 @@ type RPCTransaction struct {
 }
 
 type RosettaTxReceipt struct {
+	Type           uint8  `json:"type,omitempty"`
 	GasPrice       *big.Int
 	GasUsed        *big.Int
 	TransactionFee *big.Int

--- a/examples/ethereum/client/client.go
+++ b/examples/ethereum/client/client.go
@@ -90,6 +90,7 @@ func (c *EthereumClient) GetBlockReceipts(
 		feeAmount := new(big.Int).Mul(gasUsed, gasPrice)
 
 		receipt := &evmClient.RosettaTxReceipt{
+			Type:           ethReceipts[i].Type,
 			GasPrice:       gasPrice,
 			GasUsed:        gasUsed,
 			Logs:           ethReceipts[i].Logs,

--- a/utils/bootstrap.go
+++ b/utils/bootstrap.go
@@ -34,7 +34,7 @@ import (
 )
 
 const(
-	readTimeout = 5 * time.Second
+	ReadHeaderTimeout = time.Minute
 )
 
 // BootStrap quickly starts the Rosetta server
@@ -65,7 +65,7 @@ func BootStrap(
 	server := &http.Server{
 		Addr:    fmt.Sprintf(":%d", cfg.Port),
 		Handler: corsRouter,
-		ReadTimeout: readTimeout,
+		ReadHeaderTimeout: ReadHeaderTimeout,
 	}
 
 	// Start required services

--- a/utils/bootstrap.go
+++ b/utils/bootstrap.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/coinbase/rosetta-geth-sdk/configuration"
 	"github.com/coinbase/rosetta-geth-sdk/services"
@@ -30,6 +31,10 @@ import (
 	"github.com/coinbase/rosetta-sdk-go/server"
 	RosettaTypes "github.com/coinbase/rosetta-sdk-go/types"
 	"github.com/neilotoole/errgroup"
+)
+
+const(
+	readTimeout = 5 * time.Second
 )
 
 // BootStrap quickly starts the Rosetta server
@@ -60,6 +65,7 @@ func BootStrap(
 	server := &http.Server{
 		Addr:    fmt.Sprintf(":%d", cfg.Port),
 		Handler: corsRouter,
+		ReadTimeout: readTimeout,
 	}
 
 	// Start required services


### PR DESCRIPTION
Fixes # .

### Motivation
Rosetta-geth-sdk should populate txn type in RosettaTxReceipt

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
