### PR TITLE
fix empty result from debug_trace call

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -534,15 +534,17 @@ func (ec *SDKClient) TraceBlockByHash(
 		return nil, err
 	}
 	if err := json.Unmarshal(raw, &calls); err != nil {
+		// ignore empty address error
 		if strings.Contains(err.Error(), "hex string has length 0, want 40 for common.Address") {
 			log.Printf("block: %s, %s",blockHash.String(), err.Error() )
-		}else {
+		} else {
 			return nil, err
 		}
 	}
 	m := make(map[string][]*FlatCall)
 	for i, tx := range calls {
-		if tx.Result.Type == "" && tx.Result.From.String() == "0x0000000000000000000000000000000000000000"{
+		// ignore empty tx, an empty address will be transfer to "0x0000000000000000000000000000000000000000"
+		if tx.Result.Type == "" && tx.Result.From.String() == "0x0000000000000000000000000000000000000000" {
 			continue
 		}
 		flatCalls := FlattenTraces(tx.Result, []*FlatCall{})

--- a/client/client.go
+++ b/client/client.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"math/big"
 	"strconv"
-	"strings"
 
 	"github.com/coinbase/rosetta-geth-sdk/configuration"
 	sdkTypes "github.com/coinbase/rosetta-geth-sdk/types"
@@ -534,17 +533,12 @@ func (ec *SDKClient) TraceBlockByHash(
 		return nil, err
 	}
 	if err := json.Unmarshal(raw, &calls); err != nil {
-		// ignore empty address error
-		if strings.Contains(err.Error(), "hex string has length 0, want 40 for common.Address") {
-			log.Printf("block: %s, %s",blockHash.String(), err.Error() )
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 	m := make(map[string][]*FlatCall)
 	for i, tx := range calls {
-		// ignore empty tx, an empty address will be transfer to "0x0000000000000000000000000000000000000000"
-		if tx.Result.Type == "" && tx.Result.From.String() == "0x0000000000000000000000000000000000000000" {
+		// ignore calls with empty type 
+		if tx.Result.Type == "" {
 			continue
 		}
 		flatCalls := FlattenTraces(tx.Result, []*FlatCall{})

--- a/client/client.go
+++ b/client/client.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"math/big"
 	"strconv"
+	"strings"
 
 	"github.com/coinbase/rosetta-geth-sdk/configuration"
 	sdkTypes "github.com/coinbase/rosetta-geth-sdk/types"
@@ -533,11 +534,15 @@ func (ec *SDKClient) TraceBlockByHash(
 		return nil, err
 	}
 	if err := json.Unmarshal(raw, &calls); err != nil {
-		return nil, err
+		if strings.Contains(err.Error(), "hex string has length 0, want 40 for common.Address") {
+			log.Printf("block: %s, %s",blockHash.String(), err.Error() )
+		}else {
+			return nil, err
+		}
 	}
 	m := make(map[string][]*FlatCall)
 	for i, tx := range calls {
-		if tx.Result == nil || tx.Result.Type == "" {
+		if tx.Result.Type == "" && tx.Result.From.String() == "0x0000000000000000000000000000000000000000"{
 			continue
 		}
 		flatCalls := FlattenTraces(tx.Result, []*FlatCall{})

--- a/client/client.go
+++ b/client/client.go
@@ -537,6 +537,9 @@ func (ec *SDKClient) TraceBlockByHash(
 	}
 	m := make(map[string][]*FlatCall)
 	for i, tx := range calls {
+		if tx.Result == nil || tx.Result.Type == "" {
+			continue
+		}
 		flatCalls := FlattenTraces(tx.Result, []*FlatCall{})
 		// Ethereum native traces are guaranteed to return all transactions
 		txHash := txs[i].TxExtraInfo.TxHash.Hex()

--- a/client/tracer.go
+++ b/client/tracer.go
@@ -108,8 +108,8 @@ func (t *EVMTransfer) UnmarshalJSON(input []byte) error {
 
 // Call is an Ethereum debug trace.
 type Call struct {
-	BeforeEVMTransfers []*EVMTransfer `json:"beforeEVMTransfers"`
-	AfterEVMTransfers []*EVMTransfer `json:"afterEVMTransfers"`
+	BeforeEVMTransfers []*EVMTransfer `json:"beforeEVMTransfers.omitempty"`
+	AfterEVMTransfers []*EVMTransfer `json:"afterEVMTransfers.omitempty"`
 	Type         string         `json:"type.omitempty"`
 	From         common.Address `json:"from.omitempty"`
 	To           common.Address `json:"to.omitempty"`

--- a/client/tracer.go
+++ b/client/tracer.go
@@ -108,13 +108,13 @@ func (t *EVMTransfer) UnmarshalJSON(input []byte) error {
 
 // Call is an Ethereum debug trace.
 type Call struct {
-	BeforeEVMTransfers []*EVMTransfer `json:"beforeEVMTransfers.omitempty"`
-	AfterEVMTransfers []*EVMTransfer `json:"afterEVMTransfers.omitempty"`
-	Type         string         `json:"type.omitempty"`
-	From         common.Address `json:"from.omitempty"`
-	To           common.Address `json:"to.omitempty"`
-	Value        *big.Int       `json:"value.omitempty"`
-	GasUsed      *big.Int       `json:"gasUsed.omitempty"`
+	BeforeEVMTransfers []*EVMTransfer `json:"beforeEVMTransfers"`
+	AfterEVMTransfers []*EVMTransfer `json:"afterEVMTransfers"`
+	Type         string         `json:"type"`
+	From         common.Address `json:"from"`
+	To           common.Address `json:"to"`
+	Value        *big.Int       `json:"value"`
+	GasUsed      *big.Int       `json:"gasUsed"`
 	Revert       bool
 	ErrorMessage string  `json:"error"`
 	Calls        []*Call `json:"calls"`

--- a/client/tracer.go
+++ b/client/tracer.go
@@ -152,7 +152,7 @@ func (t *Call) UnmarshalJSON(input []byte) error {
 		BeforeEVMTransfers []*EVMTransfer `json:"beforeEVMTransfers"`
 		AfterEVMTransfers []*EVMTransfer `json:"afterEVMTransfers"`
 		Type         string         `json:"type"`
-		From         common.Address `json:"from"`
+		From         string         `json:"from"`
 		To           common.Address `json:"to"`
 		Value        *hexutil.Big   `json:"value"`
 		GasUsed      *hexutil.Big   `json:"gasUsed"`
@@ -168,7 +168,7 @@ func (t *Call) UnmarshalJSON(input []byte) error {
 	t.BeforeEVMTransfers = dec.BeforeEVMTransfers
 	t.AfterEVMTransfers = dec.AfterEVMTransfers
 	t.Type = dec.Type
-	t.From = dec.From
+	t.From = common.HexToAddress(dec.From)
 	t.To = dec.To
 	if dec.Value != nil {
 		t.Value = (*big.Int)(dec.Value)

--- a/client/tracer.go
+++ b/client/tracer.go
@@ -110,11 +110,11 @@ func (t *EVMTransfer) UnmarshalJSON(input []byte) error {
 type Call struct {
 	BeforeEVMTransfers []*EVMTransfer `json:"beforeEVMTransfers"`
 	AfterEVMTransfers []*EVMTransfer `json:"afterEVMTransfers"`
-	Type         string         `json:"type"`
-	From         common.Address `json:"from"`
-	To           common.Address `json:"to"`
-	Value        *big.Int       `json:"value"`
-	GasUsed      *big.Int       `json:"gasUsed"`
+	Type         string         `json:"type.omitempty"`
+	From         common.Address `json:"from.omitempty"`
+	To           common.Address `json:"to.omitempty"`
+	Value        *big.Int       `json:"value.omitempty"`
+	GasUsed      *big.Int       `json:"gasUsed.omitempty"`
 	Revert       bool
 	ErrorMessage string  `json:"error"`
 	Calls        []*Call `json:"calls"`


### PR DESCRIPTION
Fixes # .

when there is a failed tx, and debug_trace functions return an empty address, will get an error : "hex string has length 0, want 40 for common.Address"

fixed by ignore the error and skip the reponse


### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
