### PR TITLE
Dont pass config twice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ examples/ethereum/.ethereum/
 .github/actions/geth/.ethereum/
 
 
+/.idea/

--- a/examples/ethereum/client/client.go
+++ b/examples/ethereum/client/client.go
@@ -17,6 +17,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"github.com/coinbase/rosetta-geth-sdk/configuration"
 	"github.com/coinbase/rosetta-geth-sdk/services"
 	RosettaTypes "github.com/coinbase/rosetta-sdk-go/types"
 
@@ -28,7 +29,6 @@ import (
 	"math/big"
 
 	evmClient "github.com/coinbase/rosetta-geth-sdk/client"
-	"github.com/coinbase/rosetta-geth-sdk/examples/ethereum/config"
 	sdkTypes "github.com/coinbase/rosetta-geth-sdk/types"
 	EthTypes "github.com/ethereum/go-ethereum/core/types"
 )
@@ -161,12 +161,7 @@ func (c *EthereumClient) GetNativeTransferGasLimit(ctx context.Context, toAddres
 
 // NewEthereumClient creates a eth client that can interact with
 // Ethereum network.
-func NewEthereumClient() (*EthereumClient, error) {
-	cfg, err := config.LoadConfiguration()
-	if err != nil {
-		log.Fatalln("%w: unable to load configuration", err)
-	}
-
+func NewEthereumClient(cfg *configuration.Configuration) (*EthereumClient, error) {
 	// Use SDK to quickly create a client that support JSON RPC calls
 	evmClient, err := evmClient.NewClient(cfg, nil)
 

--- a/examples/ethereum/main.go
+++ b/examples/ethereum/main.go
@@ -35,7 +35,7 @@ func main() {
 	errors := sdkTypes.Errors
 
 	// Create a new ethereum client by leveraging SDK functionalities
-	client, err := client.NewEthereumClient()
+	client, err := client.NewEthereumClient(cfg)
 	if err != nil {
 		log.Fatalln("%w: cannot initialize client", err)
 	}


### PR DESCRIPTION
### Motivation
Currently the configuration is being parsed twice.

### Solution
Instead of parsing twice, simply pass the parsed configuration through to the client.
