### PR TITLE
Ignore transaction traces that have an empty type

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -537,6 +537,10 @@ func (ec *SDKClient) TraceBlockByHash(
 	}
 	m := make(map[string][]*FlatCall)
 	for i, tx := range calls {
+		if tx.Result.Type == "" {
+			// ignore calls with an empty type
+			continue
+		}
 		flatCalls := FlattenTraces(tx.Result, []*FlatCall{})
 		// Ethereum native traces are guaranteed to return all transactions
 		txHash := txs[i].TxExtraInfo.TxHash.Hex()

--- a/client/tracer.go
+++ b/client/tracer.go
@@ -152,7 +152,7 @@ func (t *Call) UnmarshalJSON(input []byte) error {
 		BeforeEVMTransfers []*EVMTransfer `json:"beforeEVMTransfers"`
 		AfterEVMTransfers []*EVMTransfer `json:"afterEVMTransfers"`
 		Type         string         `json:"type"`
-		From         common.Address `json:"from"`
+		From         string         `json:"from"` // string here to avoid erroring when "from" is a blank string
 		To           common.Address `json:"to"`
 		Value        *hexutil.Big   `json:"value"`
 		GasUsed      *hexutil.Big   `json:"gasUsed"`
@@ -168,7 +168,7 @@ func (t *Call) UnmarshalJSON(input []byte) error {
 	t.BeforeEVMTransfers = dec.BeforeEVMTransfers
 	t.AfterEVMTransfers = dec.AfterEVMTransfers
 	t.Type = dec.Type
-	t.From = dec.From
+	t.From = common.HexToAddress(dec.From)
 	t.To = dec.To
 	if dec.Value != nil {
 		t.Value = (*big.Int)(dec.Value)


### PR DESCRIPTION
Fixes # .

when there is a failed tx, and debug_trace functions return an empty address, will get an error : "hex string has length 0, want 40 for common.Address"

![image](https://user-images.githubusercontent.com/96205264/214354829-b668696c-0562-4cf0-9619-bf20cdcbb090.png)


### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
