### PR TITLE
[Construction][Contract-Call] Fix contract call data construction

### DIFF
--- a/services/construction/preprocess.go
+++ b/services/construction/preprocess.go
@@ -226,6 +226,14 @@ func constructContractCallData(methodSig string, methodArgs []string) ([]byte, e
 			{
 				argData = common.HexToAddress(methodArgs[i])
 			}
+		case v == "uint32":
+			{
+				u64, err := strconv.ParseUint(methodArgs[i], 10, 32)
+				if err != nil {
+					log.Fatal(err)
+				}
+				argData = uint32(u64)
+			}
 		case v == "bytes32":
 			{
 				value := [32]byte{}

--- a/services/construction/preprocess.go
+++ b/services/construction/preprocess.go
@@ -234,6 +234,12 @@ func constructContractCallData(methodSig string, methodArgs []string) ([]byte, e
 				}
 				argData = uint32(u64)
 			}
+		case strings.HasPrefix(v, "uint") || strings.HasPrefix(v, "int"):
+			{
+				value := new(big.Int)
+				value.SetString(methodArgs[i], base)
+				argData = value
+			}
 		case v == "bytes32":
 			{
 				value := [32]byte{}
@@ -242,12 +248,6 @@ func constructContractCallData(methodSig string, methodArgs []string) ([]byte, e
 					log.Fatal(err)
 				}
 				copy(value[:], bytes)
-				argData = value
-			}
-		case strings.HasPrefix(v, "uint") || strings.HasPrefix(v, "int"):
-			{
-				value := new(big.Int)
-				value.SetString(methodArgs[i], base)
 				argData = value
 			}
 		case strings.HasPrefix(v, "bytes"):

--- a/services/construction/preprocess_test.go
+++ b/services/construction/preprocess_test.go
@@ -47,6 +47,21 @@ var (
 	redeemMethodSignature    = "redeem(bytes32)"
 	redeemMethodArgs         = []string{"0x2b65269ff5a2a05ba8d589d6fb068d095c50d296c0abb17bd3e98430d8d89a36"}
 	expectedRedeemMethodArgs = []interface{}{"0x2b65269ff5a2a05ba8d589d6fb068d095c50d296c0abb17bd3e98430d8d89a36"}
+	// bridge withdraw params
+	bridgeWithdrawMethodSig  = "withdraw(address,uint256,uint32,bytes)"
+	bridgeWithdrawMethodArgs = []string{
+		"0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
+		"23535",
+		"0",
+		"0x",
+	}
+	bridgeWithdrawRedeemData         = "0x32b7006d000000000000000000000000deaddeaddeaddeaddeaddeaddeaddeaddead00000000000000000000000000000000000000000000000000000000000000005bef000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000000"
+	expectedBridgeWithdrawMethodArgs = []interface{}{
+		"0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
+		"23535",
+		"0",
+		"0x",
+	}
 )
 
 func TestConstructionPreprocess(t *testing.T) {
@@ -125,6 +140,28 @@ func TestConstructionPreprocess(t *testing.T) {
 				},
 			},
 		},
+		"happy path: Bridge Withdraw": {
+			operations: templateOperations(preprocessZeroTransferValue, ethereumCurrencyConfig, "CALL"),
+			metadata: map[string]interface{}{
+				"method_signature": bridgeWithdrawMethodSig,
+				"method_args":      bridgeWithdrawMethodArgs,
+			},
+			expectedResponse: &types.ConstructionPreprocessResponse{
+				Options: map[string]interface{}{
+					"from":             testingFromAddress,
+					"to":               testingToAddress, // it will be contract address user need to pass in operation
+					"value":            fmt.Sprint(preprocessZeroTransferValue),
+					"contract_address": testingToAddress,
+					"data":             bridgeWithdrawRedeemData,
+					"method_signature": bridgeWithdrawMethodSig,
+					"method_args":      expectedBridgeWithdrawMethodArgs,
+					"currency": map[string]interface{}{
+						"decimals": float64(18),
+						"symbol":   "ETH",
+					},
+				},
+			},
+		},
 		"happy path: Outbound transfer call with zero transfer value": {
 			operations: templateOperations(preprocessZeroTransferValue, ethereumCurrencyConfig, "CALL"),
 			metadata: map[string]interface{}{
@@ -142,7 +179,7 @@ func TestConstructionPreprocess(t *testing.T) {
 					"to":               testingToAddress, // it will be contract address user need to pass in operation
 					"value":            fmt.Sprint(preprocessZeroTransferValue),
 					"contract_address": testingToAddress,
-					"data":             "0x7b3a3c8b00000000000000000000000007865c6e87b9f70255377e024ace6630c1eaa37f000000000000000000000000b53c4cda2de7becd6ad0fe3f0ded29fc6b0aa6f600000000000000000000000000000000000000000000000000000000000f424000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000000",// nolint:lll
+					"data":             "0x7b3a3c8b00000000000000000000000007865c6e87b9f70255377e024ace6630c1eaa37f000000000000000000000000b53c4cda2de7becd6ad0fe3f0ded29fc6b0aa6f600000000000000000000000000000000000000000000000000000000000f424000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000000", // nolint:lll
 					"method_signature": "outboundTransfer(address,address,uint256,bytes)",
 					"method_args": []interface{}{
 						"0x07865c6E87B9F70255377e024ace6630C1Eaa37F",


### PR DESCRIPTION
Fixes # .
backported from here: https://github.com/Inphi/optimism-rosetta/pull/42

### Context
[constructContractCallData](https://github.com/coinbase/rosetta-geth-sdk/blob/049b6a1ad5739f6d6abdbfd576b5ca9eae0f0674/services/construction/preprocess.go#L239-L244) does not parse the MethodArgs properly
- 1. the method parses uint32 type args as a `*big.Int` type and failed abi type assertion 


### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

- Parse uint32 as uint32 type
- Add unit test for the `constructContractCallData`

#### Before
```
data, err := constructContractCallData(test.methodSig, test.methodArgs)
// err = "abi: cannot use ptr as type uint32 as argument"
```

#### After
```
data, err := constructContractCallData(test.methodSig, test.methodArgs)
// data = []byte("32b7006d000000000000000000000000deaddeaddeaddeaddeaddeaddeaddeaddead00000000000000000000000000000000000000000000000000000000000000005bef00000000000000000000000000000000000000000000000000000000000927c0000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000")
// err = nil

```

### Open questions
1. We probably should follow the optimism rosetta and implement something similar: https://github.com/Inphi/optimism-rosetta/blob/master/services/construction_service.go#L836-L880
2. The encoding is not exhaustive and we should take a more closer look at other arg types.

