### PR TITLE
Modify erc20 balance check logic

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -262,8 +262,6 @@ func (ec *SDKClient) Balance(
 		if err != nil {
 			return nil, err
 		}
-			
-		}
 
 		amount := Erc20Amount(
 			balance.Bytes(),

--- a/client/client.go
+++ b/client/client.go
@@ -125,7 +125,12 @@ func decodeHexData(data string) (*big.Int, error) {
 	const base = 16
 	decoded, ok := new(big.Int).SetString(data[2:], base)
 	if !ok {
-		return nil, fmt.Errorf("could not extract data from %s", data)
+		if data == "0x" {
+		// return 0 as balance
+		decoded = big.NewInt(0)
+		} else {
+			return nil, fmt.Errorf("could not extract data from %s", data)
+		}
 	}
 	return decoded, nil
 }
@@ -255,14 +260,8 @@ func (ec *SDKClient) Balance(
 		}
 		balance, err := decodeHexData(resp)
 		if err != nil {
-			// if the erc20 token dose exist we will get 0x 
-			if resp == "0x" {
-				log.Printf("eth_call return 0x at block %d, for account %s, with token symbol: %s and contract address: %s", *block.Index, account.Address, currency.Symbol, value.(string))
-				// return 0 as balance
-				balance = big.NewInt(0)
-			} else  {
-				return nil, err
-			}
+			return nil, err
+		}
 			
 		}
 

--- a/client/client.go
+++ b/client/client.go
@@ -125,9 +125,6 @@ func decodeHexData(data string) (*big.Int, error) {
 	const base = 16
 	decoded, ok := new(big.Int).SetString(data[2:], base)
 	if !ok {
-		if(data == "0x") {
-			return 0
-		}
 		return nil, fmt.Errorf("could not extract data from %s", data)
 	}
 	return decoded, nil

--- a/client/client.go
+++ b/client/client.go
@@ -255,8 +255,10 @@ func (ec *SDKClient) Balance(
 		}
 		balance, err := decodeHexData(resp)
 		if err != nil {
+			// if the erc20 token dose exist we will get 0x 
 			if resp == "0x" {
 				log.Printf("eth_call return 0x at block %d, for account %s, with token symbol: %s and contract address: %s", *block.Index, account.Address, currency.Symbol, value.(string))
+				// return 0 as balance
 				balance = big.NewInt(0)
 			} else  {
 				return nil, err

--- a/client/client.go
+++ b/client/client.go
@@ -125,6 +125,9 @@ func decodeHexData(data string) (*big.Int, error) {
 	const base = 16
 	decoded, ok := new(big.Int).SetString(data[2:], base)
 	if !ok {
+		if(data == "0x") {
+			return 0
+		}
 		return nil, fmt.Errorf("could not extract data from %s", data)
 	}
 	return decoded, nil
@@ -255,7 +258,13 @@ func (ec *SDKClient) Balance(
 		}
 		balance, err := decodeHexData(resp)
 		if err != nil {
-			return nil, err
+			if resp == "0x" {
+				log.Printf("eth_call return 0x at block %d, for account %s, with token symbol: %s and contract address: %s", *block.Index, account.Address, currency.Symbol, value.(string))
+				balance = big.NewInt(0)
+			} else  {
+				return nil, err
+			}
+			
 		}
 
 		amount := Erc20Amount(

--- a/client/client.go
+++ b/client/client.go
@@ -122,15 +122,14 @@ func toBlockNumArg(number *big.Int) string {
 
 // decodeHexData accepts a fully formed hex string (including the 0x prefix) and returns a big.Int
 func decodeHexData(data string) (*big.Int, error) {
+	rawData := data[2:]
+	if rawData == "" {
+		return big.NewInt(0), nil
+	}
 	const base = 16
-	decoded, ok := new(big.Int).SetString(data[2:], base)
+	decoded, ok := new(big.Int).SetString(rawData, base)
 	if !ok {
-		if data == "0x" {
-		// return 0 as balance
-		decoded = big.NewInt(0)
-		} else {
-			return nil, fmt.Errorf("could not extract data from %s", data)
-		}
+		return nil, fmt.Errorf("could not extract data from %s", data)
 	}
 	return decoded, nil
 }


### PR DESCRIPTION
Fixes # .
as title

if we query a erc20 which is not exist, it will return errors : could not extract data from 0x

![Screenshot 2023-02-09 at 2 14 00 PM](https://user-images.githubusercontent.com/96205264/217952291-435702bc-a371-4b9a-8048-6efb7726e9be.jpeg)


if an account create an erc20 and send to another address in same block
and rosetta-cli will query the previous block for balance, as the erc20 do not exist at that block, we will get 0x as reponse
in this situation I think it is ok to return 0 as balance instead of throw an error

after fix
![Screenshot 2023-02-09 at 2 08 51 PM](https://user-images.githubusercontent.com/96205264/217952420-23e675b6-3b4c-45af-a096-5c2bf88a7472.jpeg)

run a recent part of validation
![Screenshot 2023-02-09 at 2 38 11 PM](https://user-images.githubusercontent.com/96205264/217956822-9dfc5eff-8881-473c-a018-0a3fcca307ee.jpeg)


### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
