### PR TITLE
loose preprocess checking

### DIFF
--- a/services/construction/construction_service.go
+++ b/services/construction/construction_service.go
@@ -123,7 +123,7 @@ func (s *APIService) CreateOperationDescriptionContractCall() []*parser.Operatio
 		Amount: &parser.AmountDescription{
 			Exists:   true,
 			Sign:     parser.AnyAmountSign,
-			Currency: s.config.RosettaCfg.Currency,
+			// Currency: s.config.RosettaCfg.Currency,
 		},
 	}
 	nativeReceive := parser.OperationDescription{
@@ -134,7 +134,7 @@ func (s *APIService) CreateOperationDescriptionContractCall() []*parser.Operatio
 		Amount: &parser.AmountDescription{
 			Exists:   true,
 			Sign:     parser.AnyAmountSign,
-			Currency: s.config.RosettaCfg.Currency,
+			// Currency: s.config.RosettaCfg.Currency,
 		},
 	}
 

--- a/services/construction/construction_service.go
+++ b/services/construction/construction_service.go
@@ -123,7 +123,6 @@ func (s *APIService) CreateOperationDescriptionContractCall() []*parser.Operatio
 		Amount: &parser.AmountDescription{
 			Exists:   true,
 			Sign:     parser.AnyAmountSign,
-			// Currency: s.config.RosettaCfg.Currency,
 		},
 	}
 	nativeReceive := parser.OperationDescription{
@@ -134,7 +133,6 @@ func (s *APIService) CreateOperationDescriptionContractCall() []*parser.Operatio
 		Amount: &parser.AmountDescription{
 			Exists:   true,
 			Sign:     parser.AnyAmountSign,
-			// Currency: s.config.RosettaCfg.Currency,
 		},
 	}
 


### PR DESCRIPTION
Fixes # .

with this pr, we do not require operation's currency be same as our default currency

tested in blockchains who are using this sdk
construction in native and erc20 do not break after this change

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
