### PR TITLE
Add mint field in LoadedTransaction

### DIFF
--- a/.github/actions/geth/truffle/build/contracts/USDC.json
+++ b/.github/actions/geth/truffle/build/contracts/USDC.json
@@ -6503,8 +6503,8 @@
       "transactionHash": "0x8caa332b20f482f276398d61350169248635cebd05e9ebbbe6614723bc7b33a4"
     }
   },
-  "schemaVersion": "3.4.10",
-  "updatedAt": "2022-11-04T18:23:03.107Z",
+  "schemaVersion": "3.4.13",
+  "updatedAt": "2023-05-14T05:01:46.046Z",
   "networkType": "ethereum",
   "devdoc": {
     "kind": "dev",

--- a/.github/scripts/setup.sh
+++ b/.github/scripts/setup.sh
@@ -5,7 +5,7 @@ nohup make run-rosetta > /dev/null 2>&1 &
 
 nohup make run-rosetta-offline > /dev/null 2>&1 &
 
-sleep 60
+sleep 120
 
 curl -s --location --request POST 'http://localhost:8080/network/list' \
 --header 'Content-Type: application/json' \

--- a/client/client.go
+++ b/client/client.go
@@ -506,6 +506,7 @@ func (tx *RPCTransaction) LoadedTransaction() *LoadedTransaction {
 		BlockNumber: tx.TxExtraInfo.BlockNumber,
 		BlockHash:   tx.TxExtraInfo.BlockHash,
 		TxHash:      tx.TxExtraInfo.TxHash,
+		Mint:        tx.TxExtraInfo.Mint,
 	}
 	return ethTx
 }

--- a/client/types.go
+++ b/client/types.go
@@ -70,6 +70,7 @@ type TxExtraInfo struct {
 	BlockHash   *common.Hash    `json:"blockHash,omitempty"`
 	From        *common.Address `json:"from,omitempty"`
 	TxHash      *common.Hash    `json:"hash,omitempty"`
+	Mint        string          `json:"mint,omitempty"`
 }
 
 type Metadata struct {
@@ -118,6 +119,8 @@ type LoadedTransaction struct {
 
 	BaseFee      *big.Int
 	IsBridgedTxn bool
+
+	Mint string
 }
 
 type SignedTransactionWrapper struct {

--- a/client/utils.go
+++ b/client/utils.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"math/big"
 	"strings"
+	"log"
 
 	"github.com/coinbase/rosetta-geth-sdk/configuration"
 
@@ -177,4 +178,21 @@ func GenerateErc20TransferData(toAddress string, value *big.Int) []byte {
 	data = append(data, paddedAddress...)
 	data = append(data, paddedAmount...)
 	return data
+}
+
+func (tx *LoadedTransaction) GetMint() *big.Int {
+	if  tx.Mint == "" {
+		return big.NewInt(0)
+	}
+	hexString := tx.Mint[2:]
+	bigInt := new(big.Int)
+	// 16 for hexadecimal base
+	_, ok := bigInt.SetString(hexString, 16)
+
+	if !ok {
+		log.Printf("Could not convert mint to big int for %s", tx.TxHash.String())
+		return big.NewInt(0)
+	}
+
+	return bigInt
 }


### PR DESCRIPTION
Fixes # .
we find some deposit's value is less than is mint amount, this pr allow rosetta implemention get mint amount directly

tested on > 400k blocks


<img width="750" alt="Screenshot 2023-05-12 at 10 29 49 PM" src="https://github.com/coinbase/rosetta-geth-sdk/assets/96205264/7d798c21-812f-42a2-926f-f6b8995dae73">
<img width="760" alt="Screenshot 2023-05-12 at 9 20 19 PM" src="https://github.com/coinbase/rosetta-geth-sdk/assets/96205264/c30a9e13-2d75-4b4b-97c0-c05cba1017fe">


### Motivation

<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
