### PR TITLE
feat: refactor construction api

### DIFF
--- a/client/address.go
+++ b/client/address.go
@@ -15,31 +15,33 @@
 package client
 
 import (
+	"errors"
 	"log"
 
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// ChecksumAddress ensures an Ethereum hex address
-// is in Checksum Format. If the address cannot be converted,
-// it returns !ok.
-func ChecksumAddress(address string) (string, bool) {
+// ChecksumAddress ensures an address is EIP55-compliant
+func ChecksumAddress(address string) error {
 	addr, err := common.NewMixedcaseAddressFromString(address)
 	if err != nil {
-		return "", false
+		return err
 	}
 
-	return addr.Address().Hex(), true
+	if !addr.ValidChecksum() {
+		return errors.New("checksum address is not equal to original address")
+	}
+
+	return nil
 }
 
-// MustChecksum ensures an address can be converted
-// into a valid checksum. If it does not, the program
-// will exit.
+// MustChecksum ensures an address is EIP55-compliant
+// If it does not, the program will exit.
 func MustChecksum(address string) string {
-	addr, ok := ChecksumAddress(address)
-	if !ok {
+	err := ChecksumAddress(address)
+	if err != nil {
 		log.Fatalf("invalid address %s", address)
 	}
 
-	return addr
+	return address
 }

--- a/client/types.go
+++ b/client/types.go
@@ -96,11 +96,10 @@ type ParseMetadata struct {
 }
 
 type Transaction struct {
-	From  string   `json:"from"`
-	To    string   `json:"to"`
-	Value *big.Int `json:"value"`
-	Data  []byte   `json:"data"`
-	// ContractData     string          `json:"contractData"`
+	From     string                 `json:"from"`
+	To       string                 `json:"to"`
+	Value    *big.Int               `json:"value"`
+	Data     []byte                 `json:"data"`
 	Nonce    uint64                 `json:"nonce"`
 	GasPrice *big.Int               `json:"gas_price"`
 	GasLimit uint64                 `json:"gas"`

--- a/services/construction/combine.go
+++ b/services/construction/combine.go
@@ -17,7 +17,8 @@ package construction
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+
+	"errors"
 
 	"github.com/coinbase/rosetta-geth-sdk/client"
 	sdkTypes "github.com/coinbase/rosetta-geth-sdk/types"
@@ -32,22 +33,15 @@ import (
 // Combine creates a network-specific Transaction from an unsigned Transaction
 // and an array of provided signatures. The signed Transaction returned from
 // this method will be sent to the /construction/submit endpoint by the caller.
-//
 func (s *APIService) ConstructionCombine(
 	ctx context.Context,
 	req *types.ConstructionCombineRequest,
 ) (*types.ConstructionCombineResponse, *types.Error) {
 	if len(req.UnsignedTransaction) == 0 {
-		return nil, sdkTypes.WrapErr(
-			sdkTypes.ErrInvalidInput,
-			fmt.Errorf("transaction data is not provided"),
-		)
+		return nil, sdkTypes.WrapErr(sdkTypes.ErrInvalidInput, errors.New("transaction data is not provided"))
 	}
 	if len(req.Signatures) == 0 {
-		return nil, sdkTypes.WrapErr(
-			sdkTypes.ErrInvalidInput,
-			fmt.Errorf("signature is not provided"),
-		)
+		return nil, sdkTypes.WrapErr(sdkTypes.ErrInvalidInput, errors.New("signature is not provided"))
 	}
 
 	var unsignedTx client.Transaction

--- a/services/construction/construction_service.go
+++ b/services/construction/construction_service.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"errors"
+
 	sdkTypes "github.com/coinbase/rosetta-geth-sdk/types"
 
 	"github.com/coinbase/rosetta-sdk-go/parser"
@@ -63,18 +65,16 @@ func (s *APIService) CreateOperationDescription(
 	isContractCall bool,
 ) ([]*parser.OperationDescription, error) {
 	if len(operations) != numOfValidOpsForDescription {
-		return nil, fmt.Errorf("invalid number of operations")
+		return nil, errors.New("invalid number of operations")
 	}
 
 	firstCurrency := operations[0].Amount.Currency
 	secondCurrency := operations[1].Amount.Currency
-
 	if firstCurrency == nil || secondCurrency == nil {
-		return nil, fmt.Errorf("invalid currency on operation")
+		return nil, errors.New("invalid currency on operation")
 	}
-
 	if types.Hash(firstCurrency) != types.Hash(secondCurrency) {
-		return nil, fmt.Errorf("currency info doesn't match between the operations")
+		return nil, errors.New("currency doesn't match between the operations")
 	}
 
 	if isContractCall {
@@ -84,10 +84,8 @@ func (s *APIService) CreateOperationDescription(
 		j := new(big.Int)
 		j.SetString(operations[1].Amount.Value, base)
 
-		if i.Cmp(big.NewInt(0)) == 0 {
-			if j.Cmp(big.NewInt(0)) != 0 {
-				return nil, fmt.Errorf("for generic call both values should be zero")
-			}
+		if i.Cmp(big.NewInt(0)) != 0 || j.Cmp(big.NewInt(0)) != 0 {
+			return nil, errors.New("for generic call both operation values should be zero")
 		}
 		return s.CreateOperationDescriptionContractCall(), nil
 	}
@@ -95,10 +93,10 @@ func (s *APIService) CreateOperationDescription(
 	if types.Hash(firstCurrency) == types.Hash(s.config.RosettaCfg.Currency) {
 		return s.CreateOperationDescriptionNative(), nil
 	}
+
 	firstContract, firstOk := firstCurrency.Metadata[client.ContractAddressMetadata].(string)
 	_, secondOk := secondCurrency.Metadata[client.ContractAddressMetadata].(string)
-
-	// Not Native curr
+	// Non-native currency
 	if !firstOk || !secondOk {
 		return nil, fmt.Errorf("non-native currency must have contractAddress in Metadata")
 	}
@@ -116,8 +114,8 @@ func (s *APIService) CreateOperationDescriptionContractCall() []*parser.Operatio
 			Exists: true,
 		},
 		Amount: &parser.AmountDescription{
-			Exists:   true,
-			Sign:     parser.AnyAmountSign,
+			Exists: true,
+			Sign:   parser.AnyAmountSign,
 		},
 	}
 	nativeReceive := parser.OperationDescription{
@@ -126,8 +124,8 @@ func (s *APIService) CreateOperationDescriptionContractCall() []*parser.Operatio
 			Exists: true,
 		},
 		Amount: &parser.AmountDescription{
-			Exists:   true,
-			Sign:     parser.AnyAmountSign,
+			Exists: true,
+			Sign:   parser.AnyAmountSign,
 		},
 	}
 
@@ -204,16 +202,12 @@ func (s *APIService) CreateOperationDescriptionERC20(
 // ConstructionHash implements /construction/hash endpoint.
 //
 // TransactionHash returns the network-specific Transaction hash for a signed Transaction.
-//
 func (s *APIService) ConstructionHash(
 	ctx context.Context,
 	req *types.ConstructionHashRequest,
 ) (*types.TransactionIdentifierResponse, *types.Error) {
 	if len(req.SignedTransaction) == 0 {
-		return nil, sdkTypes.WrapErr(
-			sdkTypes.ErrInvalidInput,
-			fmt.Errorf("signed Transaction value is not provided"),
-		)
+		return nil, sdkTypes.WrapErr(sdkTypes.ErrInvalidInput, errors.New("signed Transaction value is not provided"))
 	}
 
 	var wrappedTx client.SignedTransactionWrapper

--- a/services/construction/construction_service.go
+++ b/services/construction/construction_service.go
@@ -74,7 +74,7 @@ func (s *APIService) CreateOperationDescription(
 		return nil, errors.New("invalid currency on operation")
 	}
 	if types.Hash(firstCurrency) != types.Hash(secondCurrency) {
-		return nil, errors.New("currency doesn't match between the operations")
+		return nil, errors.New("currency info doesn't match between the operations")
 	}
 
 	if isContractCall {
@@ -84,8 +84,10 @@ func (s *APIService) CreateOperationDescription(
 		j := new(big.Int)
 		j.SetString(operations[1].Amount.Value, base)
 
-		if i.Cmp(big.NewInt(0)) != 0 || j.Cmp(big.NewInt(0)) != 0 {
-			return nil, errors.New("for generic call both operation values should be zero")
+		if i.Cmp(big.NewInt(0)) == 0 {
+			if j.Cmp(big.NewInt(0)) != 0 {
+				return nil, errors.New("for generic call both values should be zero")
+			}
 		}
 		return s.CreateOperationDescriptionContractCall(), nil
 	}

--- a/services/construction/parse.go
+++ b/services/construction/parse.go
@@ -191,5 +191,5 @@ func hasERC20TransferData(data []byte) bool {
 	methodID := data[:4]
 	expectedMethodID, _ := erc20TransferMethodID()
 
-	return bytes.Compare(methodID, expectedMethodID) == 0
+	return bytes.Equal(methodID, expectedMethodID)
 }

--- a/services/construction/parse.go
+++ b/services/construction/parse.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"errors"
+
 	"github.com/coinbase/rosetta-geth-sdk/client"
 	sdkTypes "github.com/coinbase/rosetta-geth-sdk/types"
 
@@ -37,7 +39,6 @@ func (s *APIService) ConstructionParse(
 	request *types.ConstructionParseRequest,
 ) (*types.ConstructionParseResponse, *types.Error) {
 	var tx client.Transaction
-	// var sender common.Address
 
 	if !request.Signed {
 		err := json.Unmarshal([]byte(request.Transaction), &tx)
@@ -68,46 +69,34 @@ func (s *APIService) ConstructionParse(
 		if err != nil {
 			return nil, sdkTypes.WrapErr(sdkTypes.ErrUnableToParseIntermediateResult, err)
 		}
-		// sender = msg.From()
 		tx.From = msg.From().Hex()
 	}
 
 	//TODO: add logic for contract call parsing
-	var opMethod string
-	var value *big.Int
-	var toAddressHex string
-	// Erc20 transfer
+
+	value := tx.Value
+	opMethod := sdkTypes.CallOpType
+	fromAddress := tx.From
+	toAddress := tx.To
+
+	// ERC20 transfer
 	if len(tx.Data) != 0 && hasERC20TransferData(tx.Data) {
-		toAddress, amountSent, err := parseErc20TransferData(tx.Data)
+		address, amountSent, err := parseErc20TransferData(tx.Data)
 		if err != nil {
 			return nil, sdkTypes.WrapErr(sdkTypes.ErrInvalidInput, err)
 		}
 
 		value = amountSent
 		opMethod = sdkTypes.OpErc20Transfer
-		toAddressHex = toAddress.Hex()
-	} else {
-		value = tx.Value
-		opMethod = sdkTypes.CallOpType
-		toAddressHex = tx.To
+		toAddress = address.Hex()
 	}
 
-	// Ensure valid from address
-	checkFrom, ok := client.ChecksumAddress(tx.From)
-	if !ok {
-		return nil, sdkTypes.WrapErr(
-			sdkTypes.ErrInvalidAddress,
-			fmt.Errorf("%s is not a valid address", tx.From),
-		)
+	// Address validation
+	if err := client.ChecksumAddress(fromAddress); err != nil {
+		return nil, sdkTypes.WrapErr(sdkTypes.ErrInvalidAddress, fmt.Errorf("%s is not a valid address: %w", tx.From, err))
 	}
-
-	// Ensure valid to address
-	checkTo, ok := client.ChecksumAddress(toAddressHex)
-	if !ok {
-		return nil, sdkTypes.WrapErr(
-			sdkTypes.ErrInvalidAddress,
-			fmt.Errorf("%s is not a valid address", tx.To),
-		)
+	if err := client.ChecksumAddress(toAddress); err != nil {
+		return nil, sdkTypes.WrapErr(sdkTypes.ErrInvalidAddress, fmt.Errorf("%s is not a valid address: %w", tx.To, err))
 	}
 
 	ops := []*types.Operation{
@@ -117,7 +106,7 @@ func (s *APIService) ConstructionParse(
 				Index: 0,
 			},
 			Account: &types.AccountIdentifier{
-				Address: checkFrom,
+				Address: fromAddress,
 			},
 			Amount: &types.Amount{
 				Value:    new(big.Int).Neg(value).String(),
@@ -130,7 +119,7 @@ func (s *APIService) ConstructionParse(
 				Index: 1,
 			},
 			Account: &types.AccountIdentifier{
-				Address: checkTo,
+				Address: toAddress,
 			},
 			Amount: &types.Amount{
 				Value:    value.String(),
@@ -138,26 +127,6 @@ func (s *APIService) ConstructionParse(
 			},
 		},
 	}
-
-	// var gasPrice, _ = new(big.Int).SetString(tx.GasPrice.String(), 10) // nolint:gomnd
-	// gasUsed := tx.GasLimit * gasPrice.Uint64()
-
-	// txFee := new(big.Int).SetUint64(gasUsed)
-	// txFee = txFee.Mul(txFee, tx.GasPrice)
-
-	// feeOps := []*types.Operation{
-	// 	{
-	// 		OperationIdentifier: &types.OperationIdentifier{
-	// 			Index: 2, // nolint:gomnd
-	// 		},
-	// 		Type: sdkTypes.FeeOpType,
-	// 		// Status:  types.String(sdkTypes.SuccessStatus),
-	// 		Account: client.Account(&sender),
-	// 		Amount:  client.Amount(new(big.Int).Neg(txFee), tx.Currency),
-	// 	},
-	// }
-
-	// ops = append(ops, feeOps...)
 
 	metadata := &client.ParseMetadata{
 		Nonce:    tx.Nonce,
@@ -175,7 +144,7 @@ func (s *APIService) ConstructionParse(
 			Operations: ops,
 			AccountIdentifierSigners: []*types.AccountIdentifier{
 				{
-					Address: checkFrom,
+					Address: fromAddress,
 				},
 			},
 			Metadata: metaMap,
@@ -193,7 +162,7 @@ func (s *APIService) ConstructionParse(
 // erc20TransferMethodID calculates the first 4 bytes of the method
 // signature for transfer on an ERC20 contract
 func erc20TransferMethodID() ([]byte, error) {
-	transferFnSignature := []byte("transfer(address,uint256)")
+	transferFnSignature := []byte(client.TransferFnSignature)
 	hash := sha3.NewLegacyKeccak256()
 	if _, err := hash.Write(transferFnSignature); err != nil {
 		return nil, err
@@ -204,29 +173,23 @@ func erc20TransferMethodID() ([]byte, error) {
 
 func parseErc20TransferData(data []byte) (*common.Address, *big.Int, error) {
 	if len(data) != client.GenericTransferBytesLength {
-		return nil, nil, fmt.Errorf("incorrect length for data array")
+		return nil, nil, errors.New("incorrect length for data array")
 	}
-	methodID := getTransferMethodID()
+
+	methodID, _ := erc20TransferMethodID()
 	if hexutil.Encode(data[:4]) != hexutil.Encode(methodID) {
-		return nil, nil, fmt.Errorf("incorrect methodID signature")
+		return nil, nil, errors.New("incorrect methodID signature")
 	}
 
 	address := common.BytesToAddress(data[5:36])
 	amount := new(big.Int).SetBytes(data[37:])
-	return &address, amount, nil
-}
 
-func getTransferMethodID() []byte {
-	transferSignature := []byte(client.TransferFnSignature) // do not include spaces in the string
-	hash := sha3.NewLegacyKeccak256()
-	hash.Write(transferSignature)
-	methodID := hash.Sum(nil)[:4]
-	return methodID
+	return &address, amount, nil
 }
 
 func hasERC20TransferData(data []byte) bool {
 	methodID := data[:4]
 	expectedMethodID, _ := erc20TransferMethodID()
-	res := bytes.Compare(methodID, expectedMethodID)
-	return res == 0
+
+	return bytes.Compare(methodID, expectedMethodID) == 0
 }

--- a/services/construction/preprocess_test.go
+++ b/services/construction/preprocess_test.go
@@ -293,7 +293,7 @@ func TestConstructionPreprocess(t *testing.T) {
 			}(),
 			expectedResponse: nil,
 			expectedError: templateError(
-				AssetTypes.ErrInvalidAddress, "invalid is not a valid address"),
+				AssetTypes.ErrInvalidAddress, "invalid is not a valid address: invalid address"),
 		},
 		"error: invalid destination address": {
 			operations: func() []*types.Operation {
@@ -307,7 +307,7 @@ func TestConstructionPreprocess(t *testing.T) {
 			}(),
 			expectedResponse: nil,
 			expectedError: templateError(
-				AssetTypes.ErrInvalidAddress, "invalid is not a valid address"),
+				AssetTypes.ErrInvalidAddress, "invalid is not a valid address: invalid address"),
 		},
 		"error: missing token address": {
 			operations: templateOperations(preprocessTransferValue, &types.Currency{
@@ -334,13 +334,13 @@ func TestConstructionPreprocess(t *testing.T) {
 				"non-native currency must have contractAddress in Metadata",
 			),
 		},
-		"error: reject call with non-zero transfer value": { 
+		"error: reject call with non-zero transfer value": {
 			operations: bigAmountTemplateOperations(preprocessNoZeroTransferValue, ethereumCurrencyConfig, "CALL"),
 			metadata: map[string]interface{}{
 				"method_signature": "approve(address,uint256)",
 				"method_args":      []string{"0xD10a72Cf054650931365Cc44D912a4FD75257058", "1000"},
 			},
-			expectedResponse:  &types.ConstructionPreprocessResponse{
+			expectedResponse: &types.ConstructionPreprocessResponse{
 				Options: map[string]interface{}{
 					"from":             testingFromAddress,
 					"to":               testingToAddress, // it will be contract address user need to pass in operation

--- a/services/mapper.go
+++ b/services/mapper.go
@@ -332,8 +332,7 @@ func TraceOps(
 	// Zero-out all destroyed accounts that are removed
 	// during transaction finalization.
 	for acct, val := range destroyedAccounts {
-		_, ok := evmClient.ChecksumAddress(acct)
-		if !ok {
+		if err := evmClient.ChecksumAddress(acct); err != nil {
 			continue
 		}
 

--- a/types/errors.go
+++ b/types/errors.go
@@ -195,9 +195,8 @@ var (
 	ErrClientCallMethodInvalid     = errors.New("call method invalid")
 )
 
-// wrapErr adds details to the types.Error provided. We use a function
-// to do this so that we don't accidentially overrwrite the standard
-// errors.
+// WrapErr adds details to the types.Error provided. We use a function
+// to do this so that we don't accidentally override the standard errors.
 func WrapErr(rErr *types.Error, err error) *types.Error {
 	newErr := &types.Error{
 		Code:      rErr.Code,

--- a/utils/bootstrap.go
+++ b/utils/bootstrap.go
@@ -33,7 +33,7 @@ import (
 	"github.com/neilotoole/errgroup"
 )
 
-const(
+const (
 	ReadHeaderTimeout = time.Minute
 )
 
@@ -45,8 +45,7 @@ func BootStrap(
 	errors []*RosettaTypes.Error,
 	client construction.Client,
 ) error {
-	// The asserter automatically rejects incorrectly formatted
-	// requests.
+	// The asserter automatically rejects incorrectly formatted requests.
 	asserter, err := asserter.NewServer(
 		types.OperationTypes,
 		AssetTypes.HistoricalBalanceSupported,
@@ -58,13 +57,13 @@ func BootStrap(
 	if err != nil {
 		return fmt.Errorf("%w: could not initialize server asserter", err)
 	}
-	router := services.NewBlockchainRouter(cfg, types, errors, client, asserter)
 
+	router := services.NewBlockchainRouter(cfg, types, errors, client, asserter)
 	loggedRouter := server.LoggerMiddleware(router)
 	corsRouter := server.CorsMiddleware(loggedRouter)
 	server := &http.Server{
-		Addr:    fmt.Sprintf(":%d", cfg.Port),
-		Handler: corsRouter,
+		Addr:              fmt.Sprintf(":%d", cfg.Port),
+		Handler:           corsRouter,
 		ReadHeaderTimeout: ReadHeaderTimeout,
 	}
 


### PR DESCRIPTION
Refactor:
* Leverages `errors.New()` as `errors.New()` is 300 times faster than `fmt.Errorf()`
* EIP55-compliant support
* Improve error chain
* Add more comments for functions and code logic
* Create common functions for metadata loading
* Remove redundant info logging messages

Testing:
* Tx construction functionalities for ETH and ERC20 work well 
![Screenshot 2023-06-08 at 5 39 14 PM](https://github.com/coinbase/rosetta-geth-sdk/assets/15131537/ad886048-a46a-479b-9ace-6915e18b3c55)


### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
