### PR TITLE
feat: data api refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ func main() {
 	// Load configuration using the ENVs in the environment.
 	cfg, err := config.LoadConfiguration()
 	if err != nil {
-		log.Fatalln("%w: unable to load configuration", err)
+		log.Fatalln("unable to load configuration: %w", err)
 	}
 
 	// Load all the supported operation types, status
@@ -58,13 +58,13 @@ func main() {
 	// Create a new ethereum client by leveraging SDK functionalities
 	client, err := client.NewEthereumClient()
 	if err != nil {
-		log.Fatalln("%w: cannot initialize client", err)
+		log.Fatalln("cannot initialize client: %w", err)
 	}
 
 	// Bootstrap to start the Rosetta API server
 	err = utils.BootStrap(cfg, types, errors, client)
 	if err != nil {
-		log.Fatalln("%w: unable to bootstrap Rosetta server", err)
+		log.Fatalln("unable to bootstrap Rosetta server: %w", err)
 	}
 }
 ```

--- a/client/client.go
+++ b/client/client.go
@@ -281,28 +281,22 @@ func (ec *SDKClient) blockHeader(
 		defaultBlockNumber := ec.rosettaConfig.DefaultBlockNumber
 		if len(defaultBlockNumber) != 0 {
 			// Handle reorg issues of Optimism and Base
-			err := ec.CallContext(ctx, &header, "eth_getBlockByNumber", defaultBlockNumber, false)
-			if err != nil {
-				return nil, err
-			}
-			if err == nil && header == nil {
-				return nil, ethereum.NotFound
-			}
+			err = ec.CallContext(ctx, &header, "eth_getBlockByNumber", defaultBlockNumber, false)
 		} else {
-			header, err = ec.HeaderByNumber(ctx, nil)
+			err = ec.CallContext(ctx, &header, "eth_getBlockByNumber", ToBlockNumArg(nil), false)
 		}
 	} else {
 		if blockIdentifier.Index != nil {
-			header, err = ec.HeaderByNumber(ctx, big.NewInt(*blockIdentifier.Index))
+			err = ec.CallContext(ctx, &header, "eth_getBlockByNumber", ToBlockNumArg(big.NewInt(*blockIdentifier.Index)), false)
 		} else {
-			header, err = ec.HeaderByHash(ctx, common.HexToHash(*blockIdentifier.Hash))
+			err = ec.CallContext(ctx, &header, "eth_getBlockByHash", common.HexToHash(*blockIdentifier.Hash), false)
 		}
 	}
 
-	if err != nil {
-		return nil, fmt.Errorf("failed to get block header: %w", err)
+	if err == nil && header == nil {
+		return nil, ethereum.NotFound
 	}
-	return header, nil
+	return header, err
 }
 
 // Peers retrieves all peers of the node.

--- a/client/eth_client.go
+++ b/client/eth_client.go
@@ -29,7 +29,7 @@ func NewEthClient(endpoint string) (*EthClient, error) {
 	client, err := ethclient.Dial(endpoint)
 
 	if err != nil {
-		return nil, fmt.Errorf("%w: unable to dial node", err)
+		return nil, fmt.Errorf("unable to dial node: %w", err)
 	}
 
 	return &EthClient{client}, nil

--- a/client/rpc_client.go
+++ b/client/rpc_client.go
@@ -81,7 +81,7 @@ func NewRPCClient(endpoint string) (*RPCClient, error) {
 		Transport: defaultTransport,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("%w: unable to dial node", err)
+		return nil, fmt.Errorf("unable to dial node: %w", err)
 	}
 	return &RPCClient{client}, nil
 }

--- a/client/tracer.go
+++ b/client/tracer.go
@@ -49,7 +49,7 @@ func GetTraceConfig(useNative bool) (*tracers.TraceConfig, error) {
 func loadTraceConfig() (*tracers.TraceConfig, error) {
 	loadedFile, err := ioutil.ReadFile(tracerPath)
 	if err != nil {
-		return nil, fmt.Errorf("%w: could not load tracer file", err)
+		return nil, fmt.Errorf("could not load tracer file: %w", err)
 	}
 
 	loadedTracer := string(loadedFile)
@@ -66,19 +66,19 @@ type rpcCall struct {
 
 // EVMTransfer is an Ethereum debug trace.
 type EVMTransfer struct {
-	Purpose      string      `json:"purpose"`
-	From         *common.Address `json:"from"`
-	To           *common.Address `json:"to"`
-	Value        *big.Int       `json:"value"`
+	Purpose string          `json:"purpose"`
+	From    *common.Address `json:"from"`
+	To      *common.Address `json:"to"`
+	Value   *big.Int        `json:"value"`
 }
 
 // UnmarshalJSON is a custom unmarshaler for Call.
 func (t *EVMTransfer) UnmarshalJSON(input []byte) error {
 	type CustomTrace struct {
-		Purpose      string      `json:"purpose"`
-		From         *common.Address `json:"from"`
-		To           *common.Address `json:"to"`
-		Value        *hexutil.Big    `json:"value"`
+		Purpose string          `json:"purpose"`
+		From    *common.Address `json:"from"`
+		To      *common.Address `json:"to"`
+		Value   *hexutil.Big    `json:"value"`
 	}
 	var dec CustomTrace
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -109,40 +109,40 @@ func (t *EVMTransfer) UnmarshalJSON(input []byte) error {
 // Call is an Ethereum debug trace.
 type Call struct {
 	BeforeEVMTransfers []*EVMTransfer `json:"beforeEVMTransfers"`
-	AfterEVMTransfers []*EVMTransfer `json:"afterEVMTransfers"`
-	Type         string         `json:"type"`
-	From         common.Address `json:"from"`
-	To           common.Address `json:"to"`
-	Value        *big.Int       `json:"value"`
-	GasUsed      *big.Int       `json:"gasUsed"`
-	Revert       bool
-	ErrorMessage string  `json:"error"`
-	Calls        []*Call `json:"calls"`
+	AfterEVMTransfers  []*EVMTransfer `json:"afterEVMTransfers"`
+	Type               string         `json:"type"`
+	From               common.Address `json:"from"`
+	To                 common.Address `json:"to"`
+	Value              *big.Int       `json:"value"`
+	GasUsed            *big.Int       `json:"gasUsed"`
+	Revert             bool
+	ErrorMessage       string  `json:"error"`
+	Calls              []*Call `json:"calls"`
 }
 
 type FlatCall struct {
 	BeforeEVMTransfers []*EVMTransfer `json:"beforeEVMTransfers"`
-	AfterEVMTransfers []*EVMTransfer `json:"afterEVMTransfers"`
-	Type         string         `json:"type"`
-	From         common.Address `json:"from"`
-	To           common.Address `json:"to"`
-	Value        *big.Int       `json:"value"`
-	GasUsed      *big.Int       `json:"gasUsed"`
-	Revert       bool
-	ErrorMessage string `json:"error"`
+	AfterEVMTransfers  []*EVMTransfer `json:"afterEVMTransfers"`
+	Type               string         `json:"type"`
+	From               common.Address `json:"from"`
+	To                 common.Address `json:"to"`
+	Value              *big.Int       `json:"value"`
+	GasUsed            *big.Int       `json:"gasUsed"`
+	Revert             bool
+	ErrorMessage       string `json:"error"`
 }
 
 func (t *Call) flatten() *FlatCall {
 	return &FlatCall{
 		BeforeEVMTransfers: t.BeforeEVMTransfers,
-		AfterEVMTransfers: t.AfterEVMTransfers,
-		Type:         t.Type,
-		From:         t.From,
-		To:           t.To,
-		Value:        t.Value,
-		GasUsed:      t.GasUsed,
-		Revert:       t.Revert,
-		ErrorMessage: t.ErrorMessage,
+		AfterEVMTransfers:  t.AfterEVMTransfers,
+		Type:               t.Type,
+		From:               t.From,
+		To:                 t.To,
+		Value:              t.Value,
+		GasUsed:            t.GasUsed,
+		Revert:             t.Revert,
+		ErrorMessage:       t.ErrorMessage,
 	}
 }
 
@@ -150,15 +150,15 @@ func (t *Call) flatten() *FlatCall {
 func (t *Call) UnmarshalJSON(input []byte) error {
 	type CustomTrace struct {
 		BeforeEVMTransfers []*EVMTransfer `json:"beforeEVMTransfers"`
-		AfterEVMTransfers []*EVMTransfer `json:"afterEVMTransfers"`
-		Type         string         `json:"type"`
-		From         string         `json:"from"` // string here to avoid erroring when "from" is a blank string
-		To           common.Address `json:"to"`
-		Value        *hexutil.Big   `json:"value"`
-		GasUsed      *hexutil.Big   `json:"gasUsed"`
-		Revert       bool
-		ErrorMessage string  `json:"error"`
-		Calls        []*Call `json:"calls"`
+		AfterEVMTransfers  []*EVMTransfer `json:"afterEVMTransfers"`
+		Type               string         `json:"type"`
+		From               string         `json:"from"` // string here to avoid erroring when "from" is a blank string
+		To                 common.Address `json:"to"`
+		Value              *hexutil.Big   `json:"value"`
+		GasUsed            *hexutil.Big   `json:"gasUsed"`
+		Revert             bool
+		ErrorMessage       string  `json:"error"`
+		Calls              []*Call `json:"calls"`
 	}
 	var dec CustomTrace
 	if err := json.Unmarshal(input, &dec); err != nil {

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -91,6 +91,10 @@ type RosettaConfig struct {
 
 	// TokenWhiteList is a list of ERC20 tokens we only support
 	TokenWhiteList []Token
+
+	// DefaultBlockNumber is the default block number if block identifier is not specified
+	// This is mainly used for Optimism and Base, it can be "safe" or "finalized" to avoid reorg issues
+	DefaultBlockNumber string
 }
 
 type Token struct {

--- a/examples/ethereum/client/client.go
+++ b/examples/ethereum/client/client.go
@@ -17,6 +17,7 @@ package client
 import (
 	"context"
 	"fmt"
+
 	"github.com/coinbase/rosetta-geth-sdk/configuration"
 	"github.com/coinbase/rosetta-geth-sdk/services"
 	RosettaTypes "github.com/coinbase/rosetta-sdk-go/types"
@@ -106,10 +107,10 @@ func (c *EthereumClient) GetBlockReceipts(
 
 		if ethReceipts[i].BlockHash != blockHash {
 			return nil, fmt.Errorf(
-				"%w: expected block hash %s for Transaction but got %s",
-				sdkTypes.ErrClientBlockOrphaned,
+				"expected block hash %s for Transaction but got %s: %w",
 				blockHash.Hex(),
 				ethReceipts[i].BlockHash.Hex(),
+				sdkTypes.ErrClientBlockOrphaned,
 			)
 		}
 	}
@@ -167,7 +168,7 @@ func NewEthereumClient(cfg *configuration.Configuration) (*EthereumClient, error
 	evmClient, err := evmClient.NewClient(cfg, nil)
 
 	if err != nil {
-		log.Fatalln("%w: cannot initialize client", err)
+		log.Fatalln("cannot initialize client: %w", err)
 		return nil, err
 	}
 

--- a/examples/ethereum/config/config.go
+++ b/examples/ethereum/config/config.go
@@ -221,8 +221,6 @@ func LoadConfiguration() (*configuration.Configuration, error) {
 		config.GenesisBlockIdentifier = GoerliGenesisBlockIdentifier
 		config.ChainConfig = params.GoerliChainConfig
 		config.GethArguments = GoerliGethArguments
-	// case "":
-	// 	return nil, errors.New("NETWORK must be populated")
 	default:
 		return nil, fmt.Errorf("%s is not a valid network", networkValue)
 	}
@@ -239,7 +237,7 @@ func LoadConfiguration() (*configuration.Configuration, error) {
 	if len(envSkipGethAdmin) > 0 {
 		val, err := strconv.ParseBool(envSkipGethAdmin)
 		if err != nil {
-			return nil, fmt.Errorf("%w: unable to parse SKIP_GETH_ADMIN %s", err, envSkipGethAdmin)
+			return nil, fmt.Errorf("unable to parse SKIP_GETH_ADMIN %s: %w", envSkipGethAdmin, err)
 		}
 		config.SkipGethAdmin = val
 	}
@@ -251,14 +249,14 @@ func LoadConfiguration() (*configuration.Configuration, error) {
 
 	port, err := strconv.Atoi(portValue)
 	if err != nil || len(portValue) == 0 || port <= 0 {
-		return nil, fmt.Errorf("%w: unable to parse port %s", err, portValue)
+		return nil, fmt.Errorf("unable to parse port %s: %w", portValue, err)
 	}
 	config.Port = port
 
 	tokenFilter := os.Getenv(TokenFilterEnv)
 	tokenFilterValue, err := strconv.ParseBool(tokenFilter)
 	if err != nil {
-		return nil, fmt.Errorf("%w: unable to parse token filter %t", err, tokenFilterValue)
+		return nil, fmt.Errorf("unable to parse token filter %t: %w", tokenFilterValue, err)
 	}
 
 	payload := []configuration.Token{}

--- a/examples/ethereum/main.go
+++ b/examples/ethereum/main.go
@@ -27,7 +27,7 @@ func main() {
 	// Load configuration using the ENVs in the environment.
 	cfg, err := config.LoadConfiguration()
 	if err != nil {
-		log.Fatalln("%w: unable to load configuration", err)
+		log.Fatalln("unable to load configuration: %w", err)
 	}
 
 	// Load all the supported operation types, status
@@ -37,12 +37,12 @@ func main() {
 	// Create a new ethereum client by leveraging SDK functionalities
 	client, err := client.NewEthereumClient(cfg)
 	if err != nil {
-		log.Fatalln("%w: cannot initialize client", err)
+		log.Fatalln("cannot initialize client: %w", err)
 	}
 
 	// Bootstrap to start the Rosetta API server
 	err = utils.BootStrap(cfg, types, errors, client)
 	if err != nil {
-		log.Fatalln("%w: unable to bootstrap Rosetta server", err)
+		log.Fatalln("unable to bootstrap Rosetta server: %w", err)
 	}
 }

--- a/services/block_service.go
+++ b/services/block_service.go
@@ -205,9 +205,9 @@ func (s *BlockAPIService) GetBlock(
 	if err := json.Unmarshal(raw, &body); err != nil {
 		return nil, nil, nil, err
 	}
-	if len(body.Hash.Hex()) > 0 && len(body.Transactions) == 0 {
-		return nil, nil, nil, errors.New("block hash is populated but transactions are not, this may due to the connected node is not full node")
-	}
+	// Note: We need a full node to return a complete RPCBlock,
+	// otherwise, only body.Hash is populated. body.Transactions is empty.
+	// TODO(xiaying): log warn if len(body.Hash) > 1 && len(body.txs) == 0
 
 	var blockAuthor string
 	if s.client.GetRosettaConfig().SupportsBlockAuthor {

--- a/services/block_service.go
+++ b/services/block_service.go
@@ -83,7 +83,7 @@ func (s *BlockAPIService) populateTransactions(
 		}
 		transaction, err := s.PopulateTransaction(ctx, tx)
 		if err != nil {
-			return nil, fmt.Errorf("%w: cannot parse %s", err, tx.Transaction.Hash().Hex())
+			return nil, fmt.Errorf("cannot parse %s: %w", tx.Transaction.Hash().Hex(), err)
 		}
 		transactions = append(transactions, transaction)
 	}
@@ -191,7 +191,7 @@ func (s *BlockAPIService) GetBlock(
 	var raw json.RawMessage
 	err := s.client.CallContext(ctx, &raw, blockMethod, args...)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("%w: block fetch failed", err)
+		return nil, nil, nil, fmt.Errorf("block fetch failed: %w", err)
 	} else if len(raw) == 0 {
 		return nil, nil, nil, ethereum.NotFound
 	}
@@ -205,15 +205,15 @@ func (s *BlockAPIService) GetBlock(
 	if err := json.Unmarshal(raw, &body); err != nil {
 		return nil, nil, nil, err
 	}
-	// Note: We need a full node to return a complete RPCBlock,
-	// otherwise, only body.Hash is populated. body.Transactions is empty.
-	// TODO(xiaying): log warn if len(body.Hash) > 1 && len(body.txs) == 0
+	if len(body.Hash.Hex()) > 0 && len(body.Transactions) == 0 {
+		return nil, nil, nil, errors.New("block hash is populated but transactions are not, this may due to the connected node is not full node")
+	}
 
 	var blockAuthor string
 	if s.client.GetRosettaConfig().SupportsBlockAuthor {
 		blockAuthor, err = s.client.BlockAuthor(ctx, head.Number.Int64())
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("%w: could not get block author for %x", err, body.Hash[:])
+			return nil, nil, nil, fmt.Errorf("could not get block author for %x: %w", body.Hash[:], err)
 		}
 	}
 
@@ -232,18 +232,12 @@ func (s *BlockAPIService) GetBlock(
 			return nil, nil, nil, err
 		}
 	}
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("%w: could not get receipts for %x", err, body.Hash[:])
-	}
 
 	// Convert all txs to loaded txs
 	txs := make([]*EthTypes.Transaction, len(body.Transactions))
 	loadedTxs := make([]*client.LoadedTransaction, len(body.Transactions))
 	for i, tx := range body.Transactions {
 		txs[i] = tx.Tx
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("%w: failure getting gas price", err)
-		}
 		loadedTxs[i] = tx.LoadedTransaction()
 		loadedTxs[i].Transaction = txs[i]
 		loadedTxs[i].BaseFee = head.BaseFee
@@ -259,8 +253,8 @@ func (s *BlockAPIService) GetBlock(
 			continue
 		}
 		// Find traces based on Tx Hash
-		hsh := loadedTxs[i].TxHash.Hex()
-		if flattenedCalls, ok := m[hsh]; ok {
+		hash := loadedTxs[i].TxHash.Hex()
+		if flattenedCalls, ok := m[hash]; ok {
 			loadedTxs[i].Trace = flattenedCalls
 		}
 	}
@@ -269,7 +263,7 @@ func (s *BlockAPIService) GetBlock(
 	if s.client.GetRosettaConfig().SupportRewardTx {
 		uncles, err = s.client.GetUncles(ctx, &head, &body)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("%w: unable to get uncles", err)
+			return nil, nil, nil, fmt.Errorf("unable to get uncles: %w", err)
 		}
 	}
 
@@ -306,10 +300,8 @@ func (s *BlockAPIService) Block(
 	}
 	receipts, err := s.client.GetBlockReceipts(ctx, rpcBlock.Hash, rpcBlock.Transactions, baseFee)
 	if err != nil {
-		formtErr := fmt.Errorf("%w: could not get receipts for %x", err, rpcBlock.Hash[:])
-		return nil, AssetTypes.WrapErr(AssetTypes.ErrInternalError, formtErr)
+		return nil, AssetTypes.WrapErr(AssetTypes.ErrInternalError, fmt.Errorf("could not get receipts for %x: %w", rpcBlock.Hash[:], err))
 	}
-	// var receipts *[]client.RosettaTxReceipt = nil
 
 	for i, tx := range loadedTxns {
 		if receipts != nil {
@@ -383,7 +375,7 @@ func (s *BlockAPIService) BlockTransaction(
 
 	loadedTx, err := s.client.GetLoadedTransaction(ctx, request)
 	if err != nil {
-		return nil, AssetTypes.WrapErr(AssetTypes.ErrInternalError, fmt.Errorf("%w: unable to get loaded tx", err))
+		return nil, AssetTypes.WrapErr(AssetTypes.ErrInternalError, fmt.Errorf("unable to get loaded tx: %w", err))
 	}
 	var (
 		raw       json.RawMessage
@@ -397,14 +389,14 @@ func (s *BlockAPIService) BlockTransaction(
 		raw, flattened, traceErr = s.client.TraceTransaction(ctx, *loadedTx.TxHash)
 	}
 	if traceErr != nil {
-		return nil, AssetTypes.WrapErr(AssetTypes.ErrInternalError, fmt.Errorf("%w: unable to get tx trace", traceErr))
+		return nil, AssetTypes.WrapErr(AssetTypes.ErrInternalError, fmt.Errorf("unable to get tx trace: %w", traceErr))
 	}
 	loadedTx.RawTrace = raw
 	loadedTx.Trace = flattened
 
 	receipt, err := s.client.GetTransactionReceipt(ctx, loadedTx)
 	if err != nil {
-		return nil, AssetTypes.WrapErr(AssetTypes.ErrInternalError, fmt.Errorf("%w: unable to get tx receipt", err))
+		return nil, AssetTypes.WrapErr(AssetTypes.ErrInternalError, fmt.Errorf("unable to get tx receipt: %w", err))
 	}
 	loadedTx.Receipt = receipt
 
@@ -418,7 +410,7 @@ func (s *BlockAPIService) BlockTransaction(
 
 	transaction, err := s.PopulateTransaction(ctx, loadedTx)
 	if err != nil {
-		return nil, AssetTypes.WrapErr(AssetTypes.ErrInternalError, fmt.Errorf("%w: unable to populate tx", err))
+		return nil, AssetTypes.WrapErr(AssetTypes.ErrInternalError, fmt.Errorf("unable to populate tx: %w", err))
 	}
 
 	return &RosettaTypes.BlockTransactionResponse{

--- a/services/construction/combine_test.go
+++ b/services/construction/combine_test.go
@@ -34,9 +34,6 @@ var (
 
 func TestConstructionCombine(t *testing.T) {
 	testingClient := newTestingClient()
-	// if err != nil {
-	//	log.Fatalln("%w: unable to load testing configuration", err)
-	// }
 
 	var signatures []*types.Signature
 	_ = json.Unmarshal([]byte(combineSignaturesRaw), &signatures)

--- a/services/construction/derive_test.go
+++ b/services/construction/derive_test.go
@@ -27,9 +27,6 @@ import (
 
 func TestConstructionDerive(t *testing.T) {
 	testingClient := newTestingClient()
-	// if err != nil {
-	//	log.Fatalln("%w: unable to load testing configuration", err)
-	// }
 
 	tests := map[string]struct {
 		request          *types.ConstructionDeriveRequest

--- a/services/construction/parse_test.go
+++ b/services/construction/parse_test.go
@@ -35,9 +35,6 @@ var (
 
 func TestParse(t *testing.T) {
 	testingClient := newTestingClient()
-	// if err != nil {
-	//	log.Fatalln("%w: unable to load testing configuration", err)
-	// }
 
 	tests := map[string]struct {
 		request          *types.ConstructionParseRequest

--- a/services/construction/payloads_test.go
+++ b/services/construction/payloads_test.go
@@ -53,9 +53,6 @@ var (
 
 func TestPayloads(t *testing.T) {
 	testingClient := newTestingClient()
-	// if err != nil {
-	//	log.Fatalln("%w: unable to load testing configuration", err)
-	// }
 
 	assert.NoError(t, json.Unmarshal([]byte(payloadsRaw), &payloads))
 	assert.NoError(t, json.Unmarshal([]byte(payloadsRawERC20), &payloadsERC20))

--- a/utils/bootstrap.go
+++ b/utils/bootstrap.go
@@ -55,7 +55,7 @@ func BootStrap(
 		"",
 	)
 	if err != nil {
-		return fmt.Errorf("%w: could not initialize server asserter", err)
+		return fmt.Errorf("could not initialize server asserter: %w", err)
 	}
 
 	router := services.NewBlockchainRouter(cfg, types, errors, client, asserter)


### PR DESCRIPTION
Refactor:
* Leverage [ethclient.go](https://github.com/ethereum/go-ethereum/blob/master/ethclient/ethclient.go) as much as possible instead of building the wheel from scratch
* Consolidate util functions and balance functions
* Support default block number (i.e. `safe`, `finalized`) for reorg issues in Optimism or Base
* Improve error chain
* Add comments for readability and maintainability

Testing:
* Construction tests are passed for ETH and ERC20
* `/account/balance` and `/network/status` APIs work as expected

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
