### PR TITLE
Make the contract call encoding utility method public

### DIFF
--- a/services/construction/contract_call_data.go
+++ b/services/construction/contract_call_data.go
@@ -29,10 +29,10 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
-// constructContractCallDataGeneric constructs the data field of a transaction.
+// ConstructContractCallDataGeneric constructs the data field of a transaction.
 // The methodArgs can be already in ABI encoded format in case of a single string
 // It can also be passed in as a slice of args, which requires further encoding.
-func constructContractCallDataGeneric(methodSig string, methodArgs interface{}) ([]byte, error) {
+func ConstructContractCallDataGeneric(methodSig string, methodArgs interface{}) ([]byte, error) {
 	data, err := contractCallMethodID(methodSig)
 	if err != nil {
 		return nil, err

--- a/services/construction/contract_call_data_test.go
+++ b/services/construction/contract_call_data_test.go
@@ -65,7 +65,7 @@ func TestConstruction_ContractCallData(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			bytes, err := constructContractCallDataGeneric(test.methodSig, test.methodArgs)
+			bytes, err := ConstructContractCallDataGeneric(test.methodSig, test.methodArgs)
 			if err != nil {
 				fmt.Println(err)
 				assert.EqualError(t, err, test.expectedError.Error())

--- a/services/construction/payloads.go
+++ b/services/construction/payloads.go
@@ -102,7 +102,7 @@ func (s *APIService) ConstructionPayloads(
 			return nil, sdkTypes.WrapErr(sdkTypes.ErrInvalidInput, err)
 		}
 
-		data, err := constructContractCallDataGeneric(metadata.MethodSignature, metadata.MethodArgs)
+		data, err := ConstructContractCallDataGeneric(metadata.MethodSignature, metadata.MethodArgs)
 		if err != nil {
 			return nil, sdkTypes.WrapErr(sdkTypes.ErrInvalidInput, err)
 		}

--- a/services/construction/preprocess.go
+++ b/services/construction/preprocess.go
@@ -136,7 +136,7 @@ func loadMetadata(req *types.ConstructionPreprocessRequest, options *client.Opti
 			return fmt.Errorf("%s is not a valid method signature string", v)
 		}
 
-		data, err := constructContractCallDataGeneric(methodSigStringObj, req.Metadata["method_args"])
+		data, err := ConstructContractCallDataGeneric(methodSigStringObj, req.Metadata["method_args"])
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Motivation
We want to make this utility method `constructContractCallDataGeneric` public so that it can be used by other EVM compatible Rosetta nodes for encoding contract call inputs.

Additional reason we're doing this rather than directly using the evm client offered by this repo is that we're not ready to make change in these existing Rosetta nodes to start using this client which is an major effort. So we decide to just reuse some of the utility methods to mitigate duplicate code problem.

### Solution
We simply make this internal utility method public.

### Open questions
N/A
