### PR TITLE
Fix FeeOps duplicated index issue.

### DIFF
--- a/services/mapper.go
+++ b/services/mapper.go
@@ -184,7 +184,7 @@ func FeeOps(tx *evmClient.LoadedTransaction) []*RosettaTypes.Operation {
 
 	burntOp := &RosettaTypes.Operation{
 		OperationIdentifier: &RosettaTypes.OperationIdentifier{
-			Index: 0, // nolint:gomnd
+			Index: 2, // nolint:gomnd
 		},
 		Type:    sdkTypes.FeeOpType,
 		Status:  RosettaTypes.String(sdkTypes.SuccessStatus),


### PR DESCRIPTION
Fixes # .
In FeeOps function, there is duplicated index of ops, which is wrong, we don't allow same index ops.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
