### PR TITLE
Fix FeeOps duplicated index issue and improve geth-sdk.

### DIFF
--- a/services/construction/types.go
+++ b/services/construction/types.go
@@ -22,6 +22,7 @@ import (
 	evmClient "github.com/coinbase/rosetta-geth-sdk/client"
 	"github.com/coinbase/rosetta-geth-sdk/configuration"
 	RosettaTypes "github.com/coinbase/rosetta-sdk-go/types"
+	Eth "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	EthTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -181,4 +182,10 @@ type Client interface {
 	ParseOps(
 		tx *evmClient.LoadedTransaction,
 	) ([]*RosettaTypes.Operation, error)
+
+	// EstimateGas tries to estimate the gas needed to execute a specific transaction based on
+	// the current pending state of the backend blockchain. There is no guarantee that this is
+	// the true gas limit requirement as other transactions may be added or removed by miners,
+	// but it should provide a basis for setting a reasonable default.
+	EstimateGas(ctx context.Context, msg Eth.CallMsg) (uint64, error)
 }

--- a/services/mapper.go
+++ b/services/mapper.go
@@ -184,7 +184,7 @@ func FeeOps(tx *evmClient.LoadedTransaction) []*RosettaTypes.Operation {
 
 	burntOp := &RosettaTypes.Operation{
 		OperationIdentifier: &RosettaTypes.OperationIdentifier{
-			Index: 0, // nolint:gomnd
+			Index: 2, // nolint:gomnd
 		},
 		Type:    sdkTypes.FeeOpType,
 		Status:  RosettaTypes.String(sdkTypes.SuccessStatus),


### PR DESCRIPTION
Fixes # .
1, Fix FeeOps duplicated index Ops issue.
2, Added common function EstimateGas declaration in the type interface.

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
