### PR TITLE
fix: reth compatible trace config

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -39,7 +39,6 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core"
 	EthTypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -48,7 +47,7 @@ import (
 
 type SDKClient struct {
 	P            *params.ChainConfig
-	tc           *tracers.TraceConfig
+	tc           *RethCompatibleTraceConfig
 	customizedTc interface{}
 
 	rosettaConfig configuration.RosettaConfig
@@ -1005,7 +1004,8 @@ func (ec *SDKClient) GetBlockReceipts(
 }
 
 func (ec *SDKClient) GetNativeTransferGasLimit(ctx context.Context, toAddress string,
-	fromAddress string, value *big.Int) (uint64, error) {
+	fromAddress string, value *big.Int,
+) (uint64, error) {
 	return 0, errors.New("GetNativeTransferGasLimit not implemented")
 }
 

--- a/client/tracer.go
+++ b/client/tracer.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/eth/tracers/logger"
 )
 
 // convert raw eth data from SDKClient to rosetta
@@ -36,9 +36,28 @@ var (
 	nativeTracer  = "callTracer"
 )
 
-func GetTraceConfig(useNative bool) (*tracers.TraceConfig, error) {
+// RethCompatibleTraceConfig copies the fields from github.com/ethereum/go-ethereum/eth/tracers.TraceConfig
+// but defines json-encoding tags that use the correct casing. We've seen that geth is case-insensitive,
+// but reth implementations are case-sensitive (because they use the rust standard library `serde`).
+//
+// Using the builtin geth trace config struct when calling reth nodes causes the default tracer
+// to be used instead of callTracer, which causes the node to return huge (1.5Gb) payloads that consume
+// lots of resources on the node and client.
+type RethCompatibleTraceConfig struct {
+	*logger.Config
+
+	Tracer  *string `json:"tracer"`
+	Timeout *string `json:"timeout"`
+	Reexec  *uint64 `json:"reexec"`
+
+	// Config specific to given tracer. Note struct logger
+	// config are historically embedded in main object.
+	TracerConfig json.RawMessage `json:"tracerConfig"`
+}
+
+func GetTraceConfig(useNative bool) (*RethCompatibleTraceConfig, error) {
 	if useNative {
-		return &tracers.TraceConfig{
+		return &RethCompatibleTraceConfig{
 			Timeout: &tracerTimeout,
 			Tracer:  &nativeTracer,
 		}, nil
@@ -46,14 +65,14 @@ func GetTraceConfig(useNative bool) (*tracers.TraceConfig, error) {
 	return loadTraceConfig()
 }
 
-func loadTraceConfig() (*tracers.TraceConfig, error) {
+func loadTraceConfig() (*RethCompatibleTraceConfig, error) {
 	loadedFile, err := os.ReadFile(tracerPath)
 	if err != nil {
 		return nil, fmt.Errorf("could not load tracer file: %w", err)
 	}
 
 	loadedTracer := string(loadedFile)
-	return &tracers.TraceConfig{
+	return &RethCompatibleTraceConfig{
 		Timeout: &tracerTimeout,
 		Tracer:  &loadedTracer,
 	}, nil

--- a/services/construction/contract_call_data_test.go
+++ b/services/construction/contract_call_data_test.go
@@ -16,7 +16,6 @@ package construction
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -94,7 +93,6 @@ func TestConstruction_ContractCallData(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			bytes, err := ConstructContractCallDataGeneric(test.methodSig, test.methodArgs)
 			if err != nil {
-				fmt.Println(err)
 				assert.EqualError(t, err, test.expectedError.Error())
 			} else {
 				assert.Equal(t, test.expectedResponse, hexutil.Encode(bytes))
@@ -117,12 +115,14 @@ func TestConstruction_preprocessArgs(t *testing.T) {
 				"0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22",
 				"32941055343948244352",
 				"0",
-				"0x"},
+				"0x",
+			},
 			expectedResponse: []interface{}{
 				"0x2Ae3F1Ec7F1F5012CFEab0185bfc7aa3cf0DEc22",
 				"32941055343948244352",
 				"0",
-				"0x"},
+				"0x",
+			},
 		},
 		"happy path: method sig is empty and args is nil": {
 			methodSig:        "",


### PR DESCRIPTION


### Motivation
We noticed that in some cases our Rosetta calls were taking >60s to respond to `debug_traceBlockByHash` calls, despite our local testing showing fast responses. We also saw our clients handling huge payloads (>1.5GB) which didn't line up with our local testing either.

It turns out that Reth nodes use case-sensitive decoding on the trace config parameters, while Geth is case-INsensitive, meaning that Geth was correctly interpreting a payload like `{ "Tracer":"callTracer", "Timeout":"60s"}` but Reth was interpreting that same payload as `{ "tracer": null, "timeout": null }`.

### Solution
This changes mesh to use a reth-compatible struct for trace config instead of the one from go-ethereum. In this library we only use the trace config for encoding as an anonymous struct in the params of `CallContext` so this replacement should be safe.