### PR TITLE
fix: add doc.go files to mock packages to fix import errors

### DIFF
--- a/mocks/client/doc.go
+++ b/mocks/client/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2022 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package client contains generated mocks for the client package.
+// These mocks are used for testing purposes.
+package client

--- a/mocks/services/doc.go
+++ b/mocks/services/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2022 Coinbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package services contains generated mocks for the services package.
+// These mocks are used for testing purposes.
+package services


### PR DESCRIPTION
## Description

Fixes #146

This PR adds doc.go files to the `mocks/client` and `mocks/services` packages to ensure they are properly recognized as Go packages. This resolves the 'no required module provides package' errors when running tests.

### Changes

- Added `mocks/client/doc.go` with package documentation
- Added `mocks/services/doc.go` with package documentation

### Problem

When running `go test ./...`, the following errors occur:
```
client/client_test.go:20:2: no required module provides package github.com/coinbase/rosetta-geth-sdk/mocks/client
client/client_test.go:21:2: no required module provides package github.com/coinbase/rosetta-geth-sdk/mocks/services
```

### Solution

Go packages that contain only generated/mock files may not be properly recognized by the Go toolchain. Adding a doc.go file with proper package declaration ensures the packages are discoverable.

### Testing

After this change, `go test ./...` should run without import errors.