### PR TITLE
Fix nil pointer dereference in TraceBlockByHash

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -448,8 +448,8 @@ func (ec *SDKClient) TraceBlockByHash(
 	}
 	m := make(map[string][]*FlatCall)
 	for i, tx := range calls {
-		if tx.Result.Type == "" {
-			// ignore calls with an empty type
+		if tx.Result == nil || tx.Result.Type == "" {
+			// ignore calls with a nil result or an empty type
 			continue
 		}
 		flatCalls := FlattenTraces(tx.Result, []*FlatCall{})


### PR DESCRIPTION
## Summary
- Adds nil check for `tx.Result` before accessing `tx.Result.Type` in `TraceBlockByHash`
- Prevents panic when `debug_traceBlockByHash` returns a trace entry with a null result

## Root Cause
In `TraceBlockByHash`, the code checks `tx.Result.Type == ""` (line 451) without first checking if `tx.Result` is nil. The `Result` field is a pointer (`*Call`), so when the RPC returns `{"result": null}` for a trace entry, accessing `.Type` on a nil pointer causes a panic.

```go
// ❌ Before
if tx.Result.Type == "" {  // panics if tx.Result is nil

// ✅ After
if tx.Result == nil || tx.Result.Type == "" {
```

## Context
This panic is being observed in production on Sei EVM (rosetta-seievm) during `/block` requests. The stack trace:
```
github.com/coinbase/rosetta-geth-sdk/client.(*SDKClient).TraceBlockByHash(...)
    client/client.go:452
```

## Test plan
- [ ] Deploy downstream consumers to dev and monitor for panics disappearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)