### PR TITLE
fix(ASSET-3183): remove log.Fatal calls

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -536,10 +536,7 @@ func (ec *SDKClient) TraceReplayTransaction(
 	var raw json.RawMessage
 	err := ec.CallContext(ctx, &raw, ec.rosettaConfig.TracePrefix+"_replayTransaction", hsh, []string{"trace"})
 	if err != nil {
-		log.Fatalln(err)
-	}
-
-	if err != nil {
+		log.Print(err)
 		return nil, nil, err
 	}
 

--- a/services/construction/contract_call_data.go
+++ b/services/construction/contract_call_data.go
@@ -164,7 +164,8 @@ func encodeMethodArgsStrings(methodID []byte, methodSig string, methodArgs []str
 			{
 				u64, err := strconv.ParseUint(methodArgs[i], 10, 32)
 				if err != nil {
-					log.Fatal(err)
+					log.Print(err)
+					return nil, fmt.Errorf("failed to parse uint32 argument: %w", err)
 				}
 				argData = uint32(u64)
 			}
@@ -172,7 +173,8 @@ func encodeMethodArgsStrings(methodID []byte, methodSig string, methodArgs []str
 			{
 				u64, err := strconv.ParseUint(methodArgs[i], 10, 64)
 				if err != nil {
-					log.Fatal(err)
+					log.Print(err)
+					return nil, fmt.Errorf("failed to parse uint64 argument: %w", err)
 				}
 				argData = u64
 			}
@@ -187,7 +189,8 @@ func encodeMethodArgsStrings(methodID []byte, methodSig string, methodArgs []str
 				value := [32]byte{}
 				bytes, err := hexutil.Decode(methodArgs[i])
 				if err != nil {
-					log.Fatal(err)
+					log.Print(err)
+					return nil, fmt.Errorf("failed to parse bytes32 argument: %w", err)
 				}
 				copy(value[:], bytes)
 				argData = value
@@ -197,14 +200,16 @@ func encodeMethodArgsStrings(methodID []byte, methodSig string, methodArgs []str
 			{
 				var bytesArgs []string
 				if err := json.Unmarshal([]byte(methodArgs[i]), &bytesArgs); err != nil {
-					log.Fatal(err)
+					log.Print(err)
+					return nil, fmt.Errorf("failed to parse bytes[] argument: %w", err)
 				}
 
 				value := make([][]byte, len(bytesArgs))
 				for j, bytesArg := range bytesArgs {
 					bytes, err := hexutil.Decode(bytesArg)
 					if err != nil {
-						log.Fatal(err)
+						log.Print(err)
+						return nil, fmt.Errorf("failed to parse bytes[] argument: %w", err)
 					}
 					value[j] = bytes
 				}
@@ -216,7 +221,8 @@ func encodeMethodArgsStrings(methodID []byte, methodSig string, methodArgs []str
 				// of a "slice" when encoding. We want it to be a slice.
 				bytes, err := hexutil.Decode(methodArgs[i])
 				if err != nil {
-					log.Fatal(err)
+					log.Print(err)
+					return nil, fmt.Errorf("failed to parse bytes argument: %w", err)
 				}
 				value := make([]byte, len(bytes))
 				copy(value[:], bytes) // nolint:gocritic
@@ -230,7 +236,8 @@ func encodeMethodArgsStrings(methodID []byte, methodSig string, methodArgs []str
 			{
 				value, err := strconv.ParseBool(methodArgs[i])
 				if err != nil {
-					log.Fatal(err)
+					log.Print(err)
+					return nil, fmt.Errorf("failed to parse bool argument: %w", err)
 				}
 				argData = value
 			}


### PR DESCRIPTION
### Motivation
`log.Fatal` internally calls `os.Exit(1)` which is not what we want for an API server. Instead this should return an error which is both more idiomatic in Golang and also more correct behavior.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->
